### PR TITLE
constify readFile()'s filename

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -577,7 +577,7 @@ public:
 
     // Read file into array of bytes, and cast to uint32_t*, then return.
     // The data has been padded, so that it fits into an array uint32_t.
-    uint32_t* readFile(uint32_t& length, char* filename) {
+    uint32_t* readFile(uint32_t& length, const char* filename) {
 
         FILE* fp = fopen(filename, "rb");
         if (fp == NULL) {


### PR DESCRIPTION
    src/main.cpp:619:65: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
             uint32_t* code = readFile(filelength, "shaders/comp.spv");
                                                   ^