### PR TITLE
replace validation layer with VK_LAYER_KHRONOS_validation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -190,7 +190,7 @@ public:
 
         /*
         By enabling validation layers, Vulkan will emit warnings if the API
-        is used incorrectly. We shall enable the layer VK_LAYER_LUNARG_standard_validation,
+        is used incorrectly. We shall enable the layer VK_LAYER_KHRONOS_validation,
         which is basically a collection of several useful validation layers.
         */
         if (enableValidationLayers) {
@@ -204,12 +204,12 @@ public:
             vkEnumerateInstanceLayerProperties(&layerCount, layerProperties.data());
 
             /*
-            And then we simply check if VK_LAYER_LUNARG_standard_validation is among the supported layers.
+            And then we simply check if VK_LAYER_KHRONOS_validation is among the supported layers.
             */
             bool foundLayer = false;
             for (VkLayerProperties prop : layerProperties) {
                 
-                if (strcmp("VK_LAYER_LUNARG_standard_validation", prop.layerName) == 0) {
+                if (strcmp("VK_LAYER_KHRONOS_validation", prop.layerName) == 0) {
                     foundLayer = true;
                     break;
                 }
@@ -217,9 +217,9 @@ public:
             }
             
             if (!foundLayer) {
-                throw std::runtime_error("Layer VK_LAYER_LUNARG_standard_validation not supported\n");
+                throw std::runtime_error("Layer VK_LAYER_KHRONOS_validation not supported\n");
             }
-            enabledLayers.push_back("VK_LAYER_LUNARG_standard_validation"); // Alright, we can use this layer.
+            enabledLayers.push_back("VK_LAYER_KHRONOS_validation"); // Alright, we can use this layer.
 
             /*
             We need to enable an extension named VK_EXT_DEBUG_REPORT_EXTENSION_NAME,


### PR DESCRIPTION
This replaces the use of the `VK_LAYER_LUNARG_standard_validation` layer with the standard `VK_LAYER_KHRONOS_validation` version, making it possible to run with a standard setup (without the LunarG SDK).

I'm not sure whether there are other reasons to prefer the LunarG validation layer - this is very much my first look at Vulkan, I'm just very grateful to have access to this demo!